### PR TITLE
feat: configurable logger/timeout for `RadarClient`

### DIFF
--- a/radar.go
+++ b/radar.go
@@ -101,7 +101,7 @@ func (radar *RadarClient) prepareAndRunEntityQuery(rawUrl string, language *lang
 func (radar *RadarClient) runQuery(u *url.URL) (string, error) {
 	resp, err := radar.web.Get(u.String())
 	if err != nil {
-		fmt.Print(err.Error())
+		radar.log.Error(err.Error())
 		return "", err
 	}
 	//noinspection GoUnhandledErrorResult
@@ -111,7 +111,7 @@ func (radar *RadarClient) runQuery(u *url.URL) (string, error) {
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Print(err.Error())
+		radar.log.Error(err.Error())
 		return "", err
 	}
 	return string(body), nil

--- a/radar_test.go
+++ b/radar_test.go
@@ -1,0 +1,25 @@
+package radarapi
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	r "github.com/goapunk/radar-api-go"
+)
+
+func TestWithTimeout(t *testing.T) {
+	var expect = 180
+	radarClient := r.NewRadarClient(r.WithTimeout(180))
+	if radarClient.GetTimeout() != expect {
+		t.Errorf("expected timeout: %d, saw: %d", expect, radarClient.GetTimeout())
+	}
+}
+
+func TestWithLogger(t *testing.T) {
+	var expect = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	radarClient := r.NewRadarClient(r.WithLogger(expect))
+	if radarClient.GetLogger() != expect {
+		t.Errorf("expected json logger")
+	}
+}

--- a/search.go
+++ b/search.go
@@ -3,11 +3,12 @@ package radarapi
 import (
 	"encoding/json"
 	"fmt"
-	lang "golang.org/x/text/language"
-	"log"
+	"log/slog"
 	"net/url"
 	"strconv"
 	"strings"
+
+	lang "golang.org/x/text/language"
 )
 
 const (
@@ -39,6 +40,7 @@ type SearchBuilder struct {
 	fields   []string
 	filters  []Filter
 	baseUrl  string
+	log      *slog.Logger
 }
 
 // The response to a search request will return a list of available facets.
@@ -74,7 +76,10 @@ func (e *ResultFacet) UnmarshalJSON(data []byte) error {
 }
 
 func (radar *RadarClient) NewSearchBuilder() *SearchBuilder {
-	return &SearchBuilder{baseUrl: radar.baseUrl}
+	return &SearchBuilder{
+		baseUrl: radar.baseUrl,
+		log:     radar.log,
+	}
 }
 
 // Search the radar database for Events. Returns nil if no results were found.
@@ -179,7 +184,7 @@ func (sb *SearchBuilder) Language(language lang.Tag) {
 // Must be 0 <= limit <= 500
 func (sb *SearchBuilder) Limit(limit uint64) {
 	if limit > 500 {
-		log.Printf("warning: max. limit of 500 exceeded :%d. Limit set to 500", limit)
+		sb.log.Warn(fmt.Sprintf("warning: max. limit of 500 exceeded :%d. Limit set to 500", limit))
 	} else {
 		sb.limit = limit
 	}


### PR DESCRIPTION
https://github.com/goapunk/radar-api-go/issues/8
https://github.com/goapunk/radar-api-go/issues/7

I'm not sure if I missed any other `Print` statements around... And would like a hint about how to configure the level of the logger? Can this be done by the caller before passing in the logger? I think so?